### PR TITLE
OSS-36: Add dependabot for C# and GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,11 @@
+version: 2
+updates: 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  — package-ecosystem: “nuget”
+    directory: “/” 
+    schedule: 
+      interval: "weekly"


### PR DESCRIPTION
Goal of this PR is to cover regular updates of C# modules and GitHub actions using dependabot implementation